### PR TITLE
ADM-1953 - Improved retry policy 

### DIFF
--- a/src/main/java/streamingapi/client/LoggerFactory.java
+++ b/src/main/java/streamingapi/client/LoggerFactory.java
@@ -1,0 +1,24 @@
+package streamingapi.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.logging.Logger;
+
+/**
+ * Logger factory
+ *
+ * @author mropotica
+ */
+public class LoggerFactory {
+
+	static {
+		String path = requireNonNull(LoggerFactory.class.getClassLoader()
+				.getResource("logging.properties"))
+				.getFile();
+		System.setProperty("java.util.logging.config.file", path);
+	}
+
+	public static Logger getLogger(String name) {
+		return Logger.getLogger(name);
+	}
+}

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,5 @@
+handlers= java.util.logging.ConsoleHandler
+.level= INFO
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%4$-7s] %5$s %6$s %n


### PR DESCRIPTION
A client should only retry connection only after commit_timeout passes. This changes correlates the retry interval with the commit_timeout. Some logging improvements have been made as well.